### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### To be Released
 
+* chore(go): use go 1.17
 * Bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 
 ### 1.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/Scalingo/gopassword
 
-go 1.15
+go 1.17
 
 require github.com/stretchr/testify v1.7.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/vendor/gopkg.in/yaml.v3/go.mod
+++ b/vendor/gopkg.in/yaml.v3/go.mod
@@ -1,5 +1,0 @@
-module "gopkg.in/yaml.v3"
-
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,9 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/pmezard/go-difflib v1.0.0
+## explicit
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.7.1
-## explicit
+## explicit; go 1.13
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.