### PR TITLE
[STORY-648] feat: simplify passwords generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## To be Released
 
+* chore(go): use go 1.23
+* Raise default length from 20 to 24
+* Allow `_` only as special character
+
 ## 1.0.3
 
 * chore(go): use go 1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## To be Released
 
-* chore(go): use go 1.23
+* chore(go): use go 1.22
 * Raise default length from 20 to 24
 * Allow `_` only as special character
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## To be Released
+## 1.0.4
 
 * chore(go): use go 1.23
 * Raise default length from 20 to 24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.4
+## To be Released
 
 * chore(go): use go 1.23
 * Raise default length from 20 to 24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## To be Released
 
 * chore(go): use go 1.22
-* Raise default length from 20 to 24
+* Raise default length from 20 to 64
 * Allow `_` only as special character
 
 ## 1.0.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go Password v1.0.4
+# Go Password v1.0.3
 
 Simple password generator in Go. Use `crypto/rand`
 
@@ -17,7 +17,7 @@ Bump new version number in `CHANGELOG.md` and `README.md`.
 Commit, tag and create a new release:
 
 ```sh
-version="1.0.4"
+version="1.0.3"
 git switch --create release/${version}
 git add CHANGELOG.md README.md
 git commit -m "Bump v${version}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go Password v1.0.3
+# Go Password v1.0.4
 
 Simple password generator in Go. Use `crypto/rand`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple password generator in Go. Use `crypto/rand`
 
 ```go
-// Passowrd of 20 characters
+// Password of 24 characters
 gopassword.Generate()
 
 // Password of 42 characters
@@ -17,7 +17,7 @@ Bump new version number in `CHANGELOG.md` and `README.md`.
 Commit, tag and create a new release:
 
 ```sh
-version="1.0.3"
+version="1.0.4"
 git switch --create release/${version}
 git add CHANGELOG.md README.md
 git commit -m "Bump v${version}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple password generator in Go. Use `crypto/rand`
 
 ```go
-// Password of 24 characters
+// Password of 64 characters
 gopassword.Generate()
 
 // Password of 42 characters

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/gopassword
 
-go 1.20
+go 1.23
 
 require github.com/stretchr/testify v1.9.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/gopassword
 
-go 1.23
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 

--- a/gopassword.go
+++ b/gopassword.go
@@ -3,12 +3,14 @@ package gopassword
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
 	"strings"
 )
 
+const defaultLength = 24
+const defaultSpecialChar = "_"
+
 func Generate(n ...int) string {
-	length := 20
+	length := defaultLength
 	if len(n) > 0 {
 		length = n[0]
 	}
@@ -23,15 +25,8 @@ func Generate(n ...int) string {
 	randString := base64.StdEncoding.EncodeToString(randBytes)
 
 	password := randString[:length]
-	password = strings.Replace(password, "+", "_", -1)
-	password = strings.Replace(password, "/", "-", -1)
-
-	if password[0] == '-' {
-		password = fmt.Sprintf("_%s", password[1:])
-	}
-	if password[length-1] == '-' {
-		password = fmt.Sprintf("%s_", password[:length-1])
-	}
+	password = strings.Replace(password, "+", defaultSpecialChar, -1)
+	password = strings.Replace(password, "/", defaultSpecialChar, -1)
 
 	return password
 }

--- a/gopassword.go
+++ b/gopassword.go
@@ -25,8 +25,8 @@ func Generate(n ...int) string {
 	randString := base64.StdEncoding.EncodeToString(randBytes)
 
 	password := randString[:length]
-	password = strings.Replace(password, "+", defaultSpecialChar, -1)
-	password = strings.Replace(password, "/", defaultSpecialChar, -1)
+	password = strings.ReplaceAll(password, "+", defaultSpecialChar)
+	password = strings.ReplaceAll(password, "/", defaultSpecialChar)
 
 	return password
 }

--- a/gopassword.go
+++ b/gopassword.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const defaultLength = 24
+const defaultLength = 64
 const defaultSpecialChar = "_"
 
 func Generate(n ...int) string {

--- a/gopassword_test.go
+++ b/gopassword_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestGenerate(t *testing.T) {
 	t.Run("When we want to generate a password", func(t *testing.T) {
-		t.Run("By default, it must be 24 characters", func(t *testing.T) {
-			assert.Len(t, Generate(), 24)
+		t.Run("By default, it must be 64 characters", func(t *testing.T) {
+			assert.Len(t, Generate(), 64)
 		})
 
 		t.Run("With an argument, the generated password must have its length", func(t *testing.T) {

--- a/gopassword_test.go
+++ b/gopassword_test.go
@@ -27,7 +27,7 @@ func TestGenerate(t *testing.T) {
 			allowedCharacters := regexp.MustCompile("^[a-zA-Z0-9_]+$")
 
 			// Try various times to ensure the result is not casual
-			for _ = range 1000 {
+			for range 1000 {
 				passwd := Generate(99)
 				assert.True(t, allowedCharacters.MatchString(passwd))
 			}

--- a/gopassword_test.go
+++ b/gopassword_test.go
@@ -1,6 +1,7 @@
 package gopassword
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,22 +9,34 @@ import (
 
 func TestGenerate(t *testing.T) {
 	t.Run("When we want to generate a password", func(t *testing.T) {
-		t.Run("By default, it should be 20 characters", func(t *testing.T) {
-			assert.Len(t, Generate(), 20)
+		t.Run("By default, it must be 24 characters", func(t *testing.T) {
+			assert.Len(t, Generate(), 24)
 		})
 
-		t.Run("With an argument, the generated password should have its length", func(t *testing.T) {
+		t.Run("With an argument, the generated password must have its length", func(t *testing.T) {
+			assert.Len(t, Generate(10), 10)
 			assert.Len(t, Generate(42), 42)
+			assert.Len(t, Generate(999), 999)
 		})
 
-		t.Run("With several arguments, only the first should be considered", func(t *testing.T) {
+		t.Run("With several arguments, only the first must be considered", func(t *testing.T) {
 			assert.Len(t, Generate(10, 20, 30), 10)
+		})
+
+		t.Run("It must contain only alphanumeric or underscore characters", func(t *testing.T) {
+			allowedCharacters, _ := regexp.Compile("^[a-zA-Z0-9_]+$")
+
+			// Try various times to ensure the result is not casual
+			for _ = range 1000 {
+				passwd := Generate(99)
+				assert.True(t, allowedCharacters.MatchString(passwd))
+			}
 		})
 	})
 
 	t.Run("Given a generated password", func(t *testing.T) {
 		passwd := Generate(20)
-		t.Run("The character frequency should be low", func(t *testing.T) {
+		t.Run("The character frequency must be low", func(t *testing.T) {
 			fm := frequencyMap(passwd)
 			maxFreq := max(fm)
 			assert.LessOrEqual(t, maxFreq, 3)

--- a/gopassword_test.go
+++ b/gopassword_test.go
@@ -24,7 +24,7 @@ func TestGenerate(t *testing.T) {
 		})
 
 		t.Run("It must contain only alphanumeric or underscore characters", func(t *testing.T) {
-			allowedCharacters, _ := regexp.Compile("^[a-zA-Z0-9_]+$")
+			allowedCharacters := regexp.MustCompile("^[a-zA-Z0-9_]+$")
 
 			// Try various times to ensure the result is not casual
 			for _ = range 1000 {


### PR DESCRIPTION
* default password length is raised from 20 to 64 characters long
* generated passwords contain only alphanumeric and underscore
  characters
* not related to the issue, upgrade to go 1.22

STORY-648